### PR TITLE
Fix tcpros

### DIFF
--- a/clients/rospy/src/rospy/impl/tcpros_base.py
+++ b/clients/rospy/src/rospy/impl/tcpros_base.py
@@ -316,11 +316,14 @@ class TCPROSServer(object):
         #and then use that to do the writing
         try:
             buff_size = 4096 # size of read buffer
+            timeout = sock.gettimeout()
+            sock.settimeout(30)
             if python3 == 0:
                 #initialize read_ros_handshake_header with BytesIO for Python 3 (instead of bytesarray())    
                 header = read_ros_handshake_header(sock, StringIO(), buff_size)
             else:
                 header = read_ros_handshake_header(sock, BytesIO(), buff_size)
+            sock.settimeout(timeout)
             
             if 'topic' in header:
                 err_msg = self.topic_connection_handler(sock, client_addr, header)

--- a/clients/rospy/src/rospy/impl/tcpros_base.py
+++ b/clients/rospy/src/rospy/impl/tcpros_base.py
@@ -582,6 +582,14 @@ class TCPROSTransport(Transport):
                 #
                 # no reconnection as error is not 1.-4.
                 self.close()
+            else:
+                try:
+                    self.socket.shutdown(socket.SHUT_RDWR)
+                except:
+                    pass
+                finally:
+                    self.socket.close()
+                self.socket = None
             raise TransportInitError(str(e)) #re-raise i/o error
                 
     def _validate_header(self, header):

--- a/clients/rospy/src/rospy/impl/tcpros_base.py
+++ b/clients/rospy/src/rospy/impl/tcpros_base.py
@@ -571,7 +571,7 @@ class TCPROSTransport(Transport):
             if not isinstance(e, socket.error):
                 # FATAL: no reconnection as error is unknown
                 self.close()
-            elif not isinstance(e, socket.timeout) and e.errno not in [100, 101, 102, 103, 110, 112, 113]:
+            elif not isinstance(e, socket.timeout) and e.errno not in [100, 101, 102, 103, 104, 110, 112, 113]:
                 # reconnect in follow cases, otherwise close the socket:
                 # 1. socket.timeout: on timeouts caused by delays on wireless links
                 # 2. ENETDOWN (100), ENETUNREACH (101), ENETRESET (102), ECONNABORTED (103):
@@ -579,8 +579,10 @@ class TCPROSTransport(Transport):
                 #     are thrown on interface shutdown e.g. on reconnection in LTE networks
                 # 3. ETIMEDOUT (110): same like 1. (for completeness)
                 # 4. EHOSTDOWN (112), EHOSTUNREACH (113): while network and/or DNS-server is not reachable
+                # 5. ECONNRESET (104): The connection was reset by the peer. Connections may be backed up we
+                #     just need to try again.
                 #
-                # no reconnection as error is not 1.-4.
+                # no reconnection as error is not 1.-5.
                 self.close()
             else:
                 try:


### PR DESCRIPTION
We were seeing issues where safety_processor_state was not accepting new connections, which prevented both blackbox and warning_cone from subscribing. The change to timeout recv should prevent the accept thread from getting blocked by misbehaving senders regardless of their root cause. This also fixes one possible root cause where a failed connection would escape the reconnect logic and sit waiting for a message with never having sent a ros header (this causes a deadlock in the publishers accept loop).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/ros_comm/7)
<!-- Reviewable:end -->
