### PR TITLE
Add read param to roslaunch

### DIFF
--- a/tools/roslaunch/resources/example-param-substitution.launch
+++ b/tools/roslaunch/resources/example-param-substitution.launch
@@ -1,0 +1,3 @@
+<launch>
+  <param name="example_using_sim_time" value="$(optparam using_sim_time False)" />
+</launch>


### PR DESCRIPTION
    Add two new roslaunch substitution args, param and optparam.
    These function similarily to env and optenv, but read from what is in
    the param server at the time of argument substitution. This means the
    params for these substitutions are read *prior* to whatever ros
    params are set in the launch file. This is useful for storing global
    configuration params in the server by some prior launch file or
    process prior to launching various nodes that depend on those
    configurations. This mechanism is very useful to alter launch file
    behavior based on sensor configuration or other global configuration,
    like sim time being enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/ros_comm/8)
<!-- Reviewable:end -->
