### PR TITLE
fix getNumPublishers() to only count fully connected

### DIFF
--- a/clients/roscpp/src/libros/subscription.cpp
+++ b/clients/roscpp/src/libros/subscription.cpp
@@ -141,8 +141,19 @@ void Subscription::getInfo(XmlRpc::XmlRpcValue& info)
 
 uint32_t Subscription::getNumPublishers()
 {
-	boost::mutex::scoped_lock lock(publisher_links_mutex_);
-	return (uint32_t)publisher_links_.size();
+  boost::mutex::scoped_lock lock(publisher_links_mutex_);
+  uint32_t num_connected_publishers = 0;
+  for (V_PublisherLink::iterator c = publisher_links_.begin();
+       c != publisher_links_.end(); ++c)
+  {
+    // Only count a connection with a received header.
+    // Discern this by a non-zero length callerid.
+    if ((*c)->getCallerID().size() > 0)
+    {
+      num_connected_publishers++;
+    }
+  }
+  return num_connected_publishers;
 }
 
 void Subscription::drop()


### PR DESCRIPTION
There is code which uses getNumPublishers() being positive as a
guarantee that a call to the remote publisher's publish() is
guaranteed to send a message to the subscriber. However, because
connections which have not yet received their header are counted,
this is not true. One such user of getNumPublishers() is actionlib.
It relies on getNumPublishers() only returning postive when a publish
on the result topic would succeed.

Fix this by only counting connections with received headers. If we
have received the header, we know the remote publisher is tracking a
connection back to us and has accepted the connection and that a
call to publish() on its end will send the message.

Note that this issue is only relevant for the TCP transport, as the
UDP transport and intraprocess link have already setup their header
by the time they are added to the publication links. Since all
publisher link types update the header, including the caller ID,
counting those with caller IDs set to non-empty is sufficient to
solve the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/ros_comm/9)
<!-- Reviewable:end -->
