### PR TITLE
Upgrade roslaunch to noetic

### DIFF
--- a/tools/roslaunch/resources/example-param-substitution.launch
+++ b/tools/roslaunch/resources/example-param-substitution.launch
@@ -1,0 +1,3 @@
+<launch>
+  <param name="example_using_sim_time" value="$(optparam using_sim_time False)" />
+</launch>

--- a/tools/roslaunch/src/roslaunch/substitution_args.py
+++ b/tools/roslaunch/src/roslaunch/substitution_args.py
@@ -50,6 +50,7 @@ from roslaunch.loader import convert_value
 import math
 
 _rospack = None
+_rosmaster = None
 
 class SubstitutionException(Exception):
     """
@@ -61,6 +62,14 @@ class ArgException(SubstitutionException):
     Exception for missing $(arg) values
     """
     pass
+
+def get_rosmaster():
+    global _rosmaster
+    if _rosmaster is not None:
+        return _rosmaster
+    import rosgraph
+    _rosmaster = rosgraph.Master(caller_id="roslaunch")
+    return _rosmaster
 
 def _eval_env(name):
     try:
@@ -94,6 +103,40 @@ def _optenv(resolved, a, args, context):
     if len(args) == 0:
         raise SubstitutionException("$(optenv var) must specify an environment variable [%s]"%a)
     return resolved.replace("$(%s)" % a, _eval_optenv(args[0], default=' '.join(args[1:])))
+
+def _eval_param(name):
+    try:
+        return str(get_rosmaster().getParam(name))
+    except rosgraph.MasterError as e:
+        raise SubstitutionException("Parameter %s is not set" % name)
+
+def _param(resolved, a, args, context):
+    """
+    process $(param) arg
+    @return: updated resolved argument
+    @rtype: str
+    @raise SubstitutionException: if arg invalidly specified
+    """
+    if len(args) == 0:
+        raise SubstitutionException("$(param name) must specify the name of a parameter [%s]"%a)
+    return resolved.replace("$(%s)" % a, _eval_param(args[0]))
+
+def _eval_optparam(name, default=''):
+    try:
+        return str(get_rosmaster().getParam(name))
+    except rosgraph.MasterError as e:
+        return default
+
+def _optparam(resolved, a, args, context):
+    """
+    process $(optparam) arg
+    @return: updated resolved argument
+    @rtype: str
+    @raise SubstitutionException: if arg invalidly specified
+    """
+    if len(args) == 0:
+        raise SubstitutionException("$(optparam name) must specify the name of a parameter [%s]"%a)
+    return resolved.replace("$(%s)" % a, _eval_optparam(args[0], default=' '.join(args[1:])))
 
 def _eval_anon(id, anons):
     if id in anons:
@@ -305,7 +348,9 @@ _eval_dict={
     '__builtins__': {k: __builtins__[k] for k in ['list', 'dict', 'map', 'str', 'float', 'int']},
     'env': _eval_env,
     'optenv': _eval_optenv,
-    'find': _eval_find
+    'find': _eval_find,
+    'param': _eval_param,
+    'optparam': _eval_optparam,
 }
 # also define all math symbols and functions
 _eval_dict.update(math.__dict__)
@@ -383,6 +428,8 @@ def resolve_args(arg_str, context=None, resolve_anon=True, filename=None):
         'dirname': _dirname,
         'anon': _anon,
         'arg': _arg,
+        'param': _param,
+        'optparam': _optparam,
     }
     resolved = _resolve_args(arg_str, context, resolve_anon, commands)
     # then resolve 'find' as it requires the subsequent path to be expanded already
@@ -393,7 +440,7 @@ def resolve_args(arg_str, context=None, resolve_anon=True, filename=None):
     return resolved
 
 def _resolve_args(arg_str, context, resolve_anon, commands):
-    valid = ['find', 'env', 'optenv', 'dirname', 'anon', 'arg']
+    valid = ['find', 'env', 'optenv', 'dirname', 'anon', 'arg', 'param', 'optparam']
     resolved = arg_str
     for a in _collect_args(arg_str):
         splits = [s for s in a.split(' ') if s]


### PR DESCRIPTION
Add the ability to query the param server from roslaunch in noetic.  The first commit is cherry-picked from our kinetic-based fork of upstream's ros-comm.  We have more changes we would like to migrate, but this is the first.

In addition, to get things to work with snapcraft, I removed all of the python 2 package conditional dependencies from this branch of ros-comm.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/ros_comm/10)
<!-- Reviewable:end -->
