### PR TITLE
rospy: Fix severe bug in get_param_cached()

### DIFF
--- a/clients/rospy/src/rospy/impl/paramserver.py
+++ b/clients/rospy/src/rospy/impl/paramserver.py
@@ -187,8 +187,6 @@ class ParamServerCache(object):
                 if not type(val) == dict:
                     raise KeyError(val)
                 val = val[ns]
-            if isinstance(val, dict) and not val:
-                raise KeyError(key)
             return val
 
 _param_server_cache = None

--- a/clients/rospy/src/rospy/impl/paramserver.py
+++ b/clients/rospy/src/rospy/impl/paramserver.py
@@ -46,7 +46,8 @@ class ParamServerCache(object):
         self.lock = threading.Lock()
         self.d = None
         self.notifier = None
-        
+        self.subscribed_params = set()
+
     ## Delete parameter from cache
     def delete(self, key):
         with self.lock:
@@ -94,13 +95,13 @@ class ParamServerCache(object):
         """
         with self.lock:
             # partially borrowed from rosmaster/paramserver.py
-            namespaces = [x for x in key.split(SEP) if x]
+            path_elems = tuple(x for x in key.split(SEP) if x)
             # - last namespace is the actual key we're storing in
             d = self.d
             if d is None:
                 raise KeyError(key)
-            value_key = namespaces[-1]
-            namespaces = namespaces[:-1]
+            value_key = path_elems[-1]
+            namespaces = path_elems[:-1]
             # - descend tree to the node we're setting
             for ns in namespaces:
                 if ns not in d:
@@ -131,11 +132,12 @@ class ParamServerCache(object):
                     raise TypeError("cannot set root of parameter tree to "
                                     "non-dictionary")
                 self.d = value
+                self.subscribed_params.add(GLOBALNS)
             else:
-                namespaces = [x for x in key.split(SEP) if x]
+                path_elems = tuple(x for x in key.split(SEP) if x)
                 # - last namespace is the actual key we're storing in
-                value_key = namespaces[-1]
-                namespaces = namespaces[:-1]
+                value_key = path_elems[-1]
+                namespaces = path_elems[:-1]
                 if self.d is None:
                     self.d = {}
                 d = self.d
@@ -153,6 +155,7 @@ class ParamServerCache(object):
                         d = val
 
                 d[value_key] = value
+                self.subscribed_params.add(path_elems)
 
     def get(self, key):
         """
@@ -166,13 +169,24 @@ class ParamServerCache(object):
             if self.d is None:
                 raise KeyError(key)
             val = self.d
-            if key != GLOBALNS:
-                # split by the namespace separator, ignoring empty splits
-                namespaces = [x for x in key.split(SEP) if x]
-                for ns in namespaces:
-                    if not type(val) == dict:
-                        raise KeyError(val)
-                    val = val[ns]
+            # split by the namespace separator, ignoring empty splits
+            namespaces = tuple(x for x in key.split(SEP) if x)
+
+            if GLOBALNS not in self.subscribed_params:
+                # Make sure this key or some parent of it was actually set
+                # so that updates are subscribed.
+                is_subscribed = False
+                for i in range(len(namespaces), 0, -1):
+                    if namespaces[:i] in self.subscribed_params:
+                        is_subscribed = True
+                        break
+                if not is_subscribed:
+                    raise KeyError(key)
+
+            for ns in namespaces:
+                if not type(val) == dict:
+                    raise KeyError(val)
+                val = val[ns]
             if isinstance(val, dict) and not val:
                 raise KeyError(key)
             return val

--- a/clients/rospy/src/rospy/msproxy.py
+++ b/clients/rospy/src/rospy/msproxy.py
@@ -115,7 +115,10 @@ class MasterProxy(object):
         #NOTE: remapping occurs here!
         resolved_key = rospy.names.resolve_name(key)
         try:
-            return rospy.impl.paramserver.get_param_server_cache().get(resolved_key)
+            value = rospy.impl.paramserver.get_param_server_cache().get(resolved_key)
+            if isinstance(value, dict) and not value:
+                raise KeyError(key)
+            return value
         except KeyError:
             pass
         code, msg, value = self.target.getParam(rospy.names.get_caller_id(), resolved_key)
@@ -162,7 +165,7 @@ class MasterProxy(object):
         resolved_key = rospy.names.resolve_name(key)
         try:
             # check for value in the parameter server cache
-            return rospy.impl.paramserver.get_param_server_cache().get(resolved_key)
+            value = rospy.impl.paramserver.get_param_server_cache().get(resolved_key)
         except KeyError:
             # first access, make call to parameter server
             code, msg, value = self.target.subscribeParam(rospy.names.get_caller_id(), rospy.core.get_node_uri(), resolved_key)
@@ -170,9 +173,9 @@ class MasterProxy(object):
                 raise KeyError(key)
             # set the value in the cache so that it's marked as subscribed
             rospy.impl.paramserver.get_param_server_cache().set(resolved_key, value)
-            if isinstance(value, dict) and not value:
-                raise KeyError(key)
-            return value
+        if isinstance(value, dict) and not value:
+            raise KeyError(key)
+        return value
         
     def __delitem__(self, key):
         """


### PR DESCRIPTION
This bug is severe because it can break ordinary rospy.get_param()
after a rospy.get_param_cached() has been perfomed. And, furthermore,
rospy.log*() does a rospy.get_param_cached()!

When a parameter is set in the cache, the cached value will always be
returned, even when the caller uses ordinary rospy.get_param(). This is
as designed, as subscribeParam() is done to make the cache
receive updates from the param server whenever the value changes.

However, existing code only uses the presence of a key in the cache to
indicate whether the cached param is valid. However, this is not enough.

Suppose the param server has these contents:
    top1:
        min: 1
        max: 10

    print(rospy.get_param('/top'))
    # So far, so good. Output is:
    # {'min': 1, 'max': 10}

    print(rospy.get_param_cached('/top/min'))
    # As expected, this outputs:
    # 1
    # However, ***'s cache now contains:
    # {'top': {'min': 1}}
    # This is correct, because only the value of 'min' is cached.

    print(rospy.get_param('/top'))
    # Incorrect output:
    # {'top': {'min': 1}}
    # Because ****'s cache makes it look like /top is in the cache, but
    # it was never actually cached.

The fix is to track the actual keys that are cached in a set. Upon, only
return a cached value if either the key or a parent of it is in the set.

This was found by productioncode which attempts to get all params using
rospy.get_param('/'). This works OK as long as no calls to
rospy.get_param_cached() have been made. However, the rospy.log*()
functions all do
rospy.get_param_cached('rosout_disable_topics_generation'). So after the
first loginfo, subsequent calls to rospy.get_param('/') only the single
cached key rather than all params.

Fixes: d16296acb755 ("rospy: added get_param_cached (#1515)")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/ros_comm/15)
<!-- Reviewable:end -->
