### PR TITLE
Rosbag Recorder: Fix latched topic bug

### DIFF
--- a/tools/rosbag/include/rosbag/recorder.h
+++ b/tools/rosbag/include/rosbag/recorder.h
@@ -178,7 +178,7 @@ private:
 
     int                           exit_code_;            //!< eventual exit code
 
-    std::map<std::pair<std::string, std::string>, OutgoingMessage> latched_msgs_;
+    std::map<std::pair<std::string, std::string>, topic_tools::ShapeShifter::ConstPtr> latched_msgs_;
 
     boost::condition_variable_any queue_condition_;      //!< conditional variable for queue
     boost::mutex                  queue_mutex_;          //!< mutex for queue

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -364,7 +364,7 @@ void Recorder::doQueue(const ros::MessageEvent<topic_tools::ShapeShifter const>&
                 ros::M_string::const_iterator it2 = out.connection_header->find("callerid");
                 if (it2 != out.connection_header->end())
                 {
-                    latched_msgs_.insert({{subscriber->getTopic(), it2->second}, out});
+                    latched_msgs_[{subscriber->getTopic(), it2->second}] = out.msg;
                 }
             }
         }
@@ -480,7 +480,7 @@ void Recorder::startWriting() {
         {
             // Overwrite the original receipt time, otherwise the new bag will
             // have a gap before the new messages start.
-            bag_.write(out.second.topic, now, *out.second.msg);
+            bag_.write(out.first.first, now, *out.second);
         }
     }
 


### PR DESCRIPTION
This bug affected latched topics that were published more than once
per recording session, and only when the `--repeat_latched` option
was set.

Latched messages were added to a std::map object using the `insert`
call. This call adds a new element to a map only if one does not yet
exist for that key. This causes the first latched messages to be the
only ones recorded at the start of each split bagfile, not the most
recent messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/ros_comm/16)
<!-- Reviewable:end -->
