### PR TITLE
Set tcp_nodelay to true by defualt, always write immediately

### DIFF
--- a/clients/roscpp/include/ros/transport_hints.h
+++ b/clients/roscpp/include/ros/transport_hints.h
@@ -93,7 +93,7 @@ public:
     M_string::iterator it = options_.find("tcp_nodelay");
     if (it == options_.end())
     {
-      return false;
+      return true;
     }
 
     const std::string& val = it->second;

--- a/clients/roscpp/src/libros/connection.cpp
+++ b/clients/roscpp/src/libros/connection.cpp
@@ -213,7 +213,6 @@ void Connection::writeTransport()
       writing_ = false;
       return;
     }
-
     write_sent_ += bytes_sent;
 
     if (bytes_sent < (int)write_size_ - (int)write_sent_)
@@ -247,6 +246,11 @@ void Connection::writeTransport()
     if (!has_write_callback_)
     {
       transport_->disableWrite();
+    }
+    else
+    {
+      // There is still more to write, wait for connection to be writable
+      transport_->enableWrite();
     }
   }
 
@@ -305,13 +309,14 @@ void Connection::write(const boost::shared_array<uint8_t>& buffer, uint32_t size
     has_write_callback_ = 1;
   }
 
-  transport_->enableWrite();
-
-  if (immediate)
-  {
-    // write immediately if possible
-    writeTransport();
-  }
+  // Always write immediately.
+  // By not adding the connetion to the poll_set via enableWrite() the normal
+  // case for most messages and connections will be to immediately write
+  // without the need to signal the poll set, add the connection to the epoll,
+  // wait for writable, remove from the poll_set etc. If the write eventually
+  // would block, then we add the connection to the poll_set via enableWrite()
+  // after getting an incomplete write or an EAGAIN.
+  writeTransport();
 }
 
 void Connection::onDisconnect(const TransportPtr& transport)


### PR DESCRIPTION
    First, change the default tcp_nodelay value from "false" to "true"  
    Because our ROS system is entirely contained to a local network, we do
    not need tcp_nodelay to be "false".

    Second, always write immediately in Connection. By not adding the connection to
    the poll_set via enableWrite() the normal case for most messages and
    connections will be to immediately write without the need to signal the
    poll set, add the connection to the epoll, wait for writable, remove
    from the poll_set etc. If the write eventually would block, then we add
    the connection to the poll_set via enableWrite() after getting an
    incomplete write or an EAGAIN.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/ros_comm/17)
<!-- Reviewable:end -->
