### PR TITLE
Set default queue size for rospy subscriber to 100

### DIFF
--- a/clients/rospy/src/rospy/topics.py
+++ b/clients/rospy/src/rospy/topics.py
@@ -562,6 +562,8 @@ class Subscriber(Topic):
 
         # last person to set these to non-defaults wins, not much way
         # around this
+        if queue_size is None:
+            queue_size = 100
         if queue_size is not None:
             self.impl.set_queue_size(queue_size)
         if buff_size != DEFAULT_BUFF_SIZE:
@@ -645,7 +647,11 @@ class _SubscriberImpl(_TopicImpl):
         @type  queue_size: int
         """
         if queue_size == -1:
-            self.queue_size = None
+            queue_size = 100
+            self.queue_size = queue_size
+        elif queue_size is None:
+            queue_size = 100
+            self.queue_size = queue_size
         elif queue_size == 0:
             raise ROSException("queue size may not be set to zero")
         elif queue_size is not None and type(queue_size) != int:


### PR DESCRIPTION
Normally the default queue size is None, which has the potential to
cause our subscribers to buffer without an upper bound. We can avoid
this by setting a new default.

ROS-658

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/ros_comm/18)
<!-- Reviewable:end -->
