### PR TITLE
Fix python3.10 collections

### DIFF
--- a/tools/rosmsg/src/rosmsg/__init__.py
+++ b/tools/rosmsg/src/rosmsg/__init__.py
@@ -75,7 +75,7 @@ def construct_ordered_mapping(self, node, deep=False):
     mapping = collections.OrderedDict()
     for key_node, value_node in node.value:
         key = self.construct_object(key_node, deep=deep)
-        if not isinstance(key, collections.Hashable):
+        if not isinstance(key, collections.abc.Hashable):
             raise yaml.constructor.ConstructorError("while constructing a mapping", node.start_mark,
                     "found unhashable key", key_node.start_mark)
         value = self.construct_object(value_node, deep=deep)


### PR DESCRIPTION
python 3.10

collections abstract base classes are now under
collections.abc in python 3.10.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/badgertechnologies/ros_comm/19)
<!-- Reviewable:end -->
