### PR TITLE
pmon: change sleep to 1.0 seconds from 0.1

### DIFF
--- a/tools/roslaunch/src/roslaunch/pmon.py
+++ b/tools/roslaunch/src/roslaunch/pmon.py
@@ -510,11 +510,11 @@ class ProcessMonitor(Thread):
                 # it has a handler. We can either use win32api.Sleep OR....catch
                 # the exception
                 try:
-                     time.sleep(0.1)
+                     time.sleep(1.0)
                 except IOError:
                     pass
             else:
-                 time.sleep(0.1)
+                 time.sleep(1.0)
                     
             if self.has_main_thread_jobs():
                 self.do_main_thread_jobs()


### PR DESCRIPTION
roslaunch when waiting for processes to exit eats a lot of resources waking up every 0.1 seconds to check on things. Change this to a 1.0 second sleep. The resources used to wake add up. For our robot, this is about 5% of a CPU core wasted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/ros_comm/20)
<!-- Reviewable:end -->
