### PR TITLE
roslaunch: Return non-zero exit code for required nodes

### DIFF
--- a/tools/roslaunch/src/roslaunch/__init__.py
+++ b/tools/roslaunch/src/roslaunch/__init__.py
@@ -250,6 +250,7 @@ def handle_exception(roslaunch_core, logger, msg, e):
 def main(argv=sys.argv):
     options = None
     logger = None
+    exit_code = 0
     try:
         from . import rlutil
         parser = _get_optparse()
@@ -313,6 +314,7 @@ def main(argv=sys.argv):
                                                sigint_timeout=options.sigint_timeout,
                                                sigterm_timeout=options.sigterm_timeout)
             c.run()
+            exit_code = c.exit_code
         else:
             logger.info('starting in server mode')
 
@@ -346,6 +348,7 @@ def main(argv=sys.argv):
                     sigterm_timeout=options.sigterm_timeout)
             p.start()
             p.spin()
+            exit_code = p.exit_code
 
     except RLException as e:
         handle_exception(roslaunch_core, logger, "RLException: ", e)
@@ -363,6 +366,7 @@ def main(argv=sys.argv):
             try: os.unlink(options.pid_fn)
             except os.error: pass
 
+    sys.exit(exit_code)
 
 if __name__ == '__main__':
     main()

--- a/tools/roslaunch/src/roslaunch/child.py
+++ b/tools/roslaunch/src/roslaunch/child.py
@@ -85,6 +85,7 @@ class ROSLaunchChild(object):
         self.pm = None
         self.sigint_timeout = sigint_timeout
         self.sigterm_timeout = sigterm_timeout
+        self.exit_code = 0
 
         roslaunch.pmon._init_signal_handlers()
 
@@ -126,6 +127,7 @@ class ROSLaunchChild(object):
             if self.pm:
                 self.pm.shutdown()
                 self.pm.join()
+                self.exit_code = self.pm.exit_code
             if self.child_server:
                 self.child_server.shutdown('roslaunch child complete')
 
@@ -133,3 +135,4 @@ class ROSLaunchChild(object):
         if self.pm:
             self.pm.shutdown()
             self.pm.join()
+            self.exit_code = self.pm.exit_code

--- a/tools/roslaunch/src/roslaunch/launch.py
+++ b/tools/roslaunch/src/roslaunch/launch.py
@@ -292,6 +292,7 @@ class ROSLaunchRunner(object):
         self.is_child = is_child
         self.is_core = is_core
         self.is_rostest = is_rostest
+        self.exit_code = 0
         self.num_workers = num_workers
         self.timeout = timeout
         self.master_logger_level = master_logger_level
@@ -629,6 +630,7 @@ class ROSLaunchRunner(object):
             printlog("shutting down processing monitor...")
             self.logger.info("shutting down processing monitor %s"%self.pm)            
             self.pm.shutdown()
+            self.exit_code = self.pm.exit_code
             self.pm.join()
             self.pm = None
             printlog("... shutting down processing monitor complete")

--- a/tools/roslaunch/src/roslaunch/parent.py
+++ b/tools/roslaunch/src/roslaunch/parent.py
@@ -151,6 +151,7 @@ class ROSLaunchParent(object):
         self._shutting_down = False
         
         self.config = self.runner = self.server = self.pm = self.remote_runner = None
+        self.exit_code = 0
 
     def _load_config(self):
         self.config = roslaunch.config.load_config_default(self.roslaunch_files, self.port,
@@ -286,6 +287,7 @@ class ROSLaunchParent(object):
         if self.pm:
             self.pm.shutdown()
             self.pm.join()
+            self.exit_code = self.pm.exit_code
         
     def start(self, auto_terminate=True):
         """

--- a/tools/roslaunch/src/roslaunch/pmon.py
+++ b/tools/roslaunch/src/roslaunch/pmon.py
@@ -312,6 +312,7 @@ class ProcessMonitor(Thread):
         self.procs = []
         self.plock = RLock()
         self.is_shutdown = False
+        self.exit_code = 0
         self.done = False        
         self.daemon = True
         self.reacquire_signals = set()
@@ -564,7 +565,12 @@ class ProcessMonitor(Thread):
                                 p.required, p.exit_code)
                         exit_code_str = p.get_exit_description()
                         if p.required:
-                            printerrlog('='*80+"REQUIRED process [%s] has died!\n%s\nInitiating shutdown!\n"%(p.name, exit_code_str)+'='*80)
+                            msg = (f"{'=' * 80}REQUIRED process [{p.name}] has died!\n"
+                                   f"{exit_code_str}\n")
+                            if p.exit_code != 0:
+                                self.exit_code = p.exit_code
+                                msg += f"Non-zero exit code: ({p.exit_code})\n"
+                            printerrlog(f"{msg}Initiating shutdown!\n{'=' * 80}")
                             self.is_shutdown = True
                         elif not p in respawn:
                             if p.exit_code:


### PR DESCRIPTION
If a "required" node in a launch file goes down, we really want to pass the error code up through the system; specifically to systemd. We can use this information to do things like attempt restarts. This was an overlooked feature of roslaunch, which always returns zero if nodes die.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/ros_comm/21)
<!-- Reviewable:end -->
