### PR TITLE
rospy: unsub params on shutdown

### DIFF
--- a/clients/rospy/src/rospy/msproxy.py
+++ b/clients/rospy/src/rospy/msproxy.py
@@ -168,6 +168,7 @@ class MasterProxy(object):
             value = rospy.impl.paramserver.get_param_server_cache().get(resolved_key)
         except KeyError:
             # first access, make call to parameter server
+            rospy.core.add_shutdown_hook(self.preshutdown_callback)
             code, msg, value = self.target.subscribeParam(rospy.names.get_caller_id(), rospy.core.get_node_uri(), resolved_key)
             if code != 1: #unwrap value with Python semantics
                 raise KeyError(key)
@@ -211,3 +212,12 @@ class MasterProxy(object):
             return value.__iter__()
         else:
             raise rospy.exceptions.ROSException("cannot retrieve parameter names: %s"%msg)
+
+    def unsubscribe_params(self):
+        for key in rospy.impl.paramserver.get_param_server_cache().subscribed_params:
+            self.target.unsubscribeParam(rospy.names.get_caller_id(), rospy.core.get_node_uri(), key[0])
+
+    def preshutdown_callback(self, reason):
+        # If we don't do this roscore will keep this node as active since it
+        # still has an active param subscription and won't free the node.
+        self.unsubscribe_params()


### PR DESCRIPTION
roscore will only clean up a node if all of its subscriptions have been unregistered. This means that any rospy node that uses roslog would not get cleaned up by roscore. If the node is then restarted it will attempt to send a shutdown to the previous node because it shared the same node, even though it had actually shutdown.

To complicate this further since the original node shutdown another node might have been assigned the same address and then it would randomly receive the shutdown request even though it didn't actually conflict.

These changes will ensure that we unregister any param that we had subscribed for. Now the rospy nodes will actually get properly cleaned up in roscore.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/BadgerTechnologies/ros_comm/23)
<!-- Reviewable:end -->
